### PR TITLE
Second move

### DIFF
--- a/lib/elixir_tic_tac_toe_basic.ex
+++ b/lib/elixir_tic_tac_toe_basic.ex
@@ -7,8 +7,19 @@ defmodule ElixirTicTacToeBasic do
 
   def start(%{ui: ui, player: player} = config) do
     config
+    |> start_game()
+    |> take_turn()
+    |> take_turn()
+  end
+
+  defp start_game(%{ui: ui, player: player} = config) do
+    config
     |> ui.welcome()
     |> ui.display_board()
+  end
+
+  defp take_turn(%{ui: ui, player: player} = config) do
+    config
     |> player.move()
     |> ui.display_board()
   end

--- a/lib/elixir_tic_tac_toe_basic/cli.ex
+++ b/lib/elixir_tic_tac_toe_basic/cli.ex
@@ -10,8 +10,11 @@ defmodule ElixirTicTacToeBasic.CLI do
       prompter: ElixirTicTacToeBasic.Prompter,
       player: ElixirTicTacToeBasic.Player,
       board: ElixirTicTacToeBasic.Board.new(),
-      current_player: "X",
-      current_move: nil
+      current_player: nil,
+      current_move: nil,
+      gets: fn state, prompt ->
+        Map.put(state, :current_move, IO.gets(prompt))
+      end
     })
   end
 end

--- a/lib/elixir_tic_tac_toe_basic/cli.ex
+++ b/lib/elixir_tic_tac_toe_basic/cli.ex
@@ -9,6 +9,7 @@ defmodule ElixirTicTacToeBasic.CLI do
       presenter: ElixirTicTacToeBasic.Presenter,
       prompter: ElixirTicTacToeBasic.Prompter,
       player: ElixirTicTacToeBasic.Player,
+      validator: ElixirTicTacToeBasic.Validator,
       board: ElixirTicTacToeBasic.Board.new(),
       current_player: nil,
       current_move: nil,

--- a/lib/elixir_tic_tac_toe_basic/player.ex
+++ b/lib/elixir_tic_tac_toe_basic/player.ex
@@ -3,10 +3,18 @@ defmodule ElixirTicTacToeBasic.Player do
   This module provides functions for making moves in the game.
   """
 
-  def move(%{prompter: prompter} = state) do
+  def move(%{prompter: prompter, gets: gets} = state) do
     state
-    |> prompter.get_input()
+    |> set_current_player()
+    |> prompter.get_input(gets)
     |> update_board()
+    |> reset_current_move()
+  end
+
+  defp set_current_player(state) do
+    Map.update(state, :current_player, "X", fn current_player ->
+      if current_player == nil or current_player == "O", do: "X", else: "O"
+    end)
   end
 
   defp update_board(
@@ -15,5 +23,9 @@ defmodule ElixirTicTacToeBasic.Player do
     Map.update(state, :board, board, fn board ->
       Map.put(board, current_move, current_player)
     end)
+  end
+
+  defp reset_current_move(state) do
+    Map.put(state, :current_move, nil)
   end
 end

--- a/lib/elixir_tic_tac_toe_basic/player.ex
+++ b/lib/elixir_tic_tac_toe_basic/player.ex
@@ -8,7 +8,6 @@ defmodule ElixirTicTacToeBasic.Player do
     |> set_current_player()
     |> prompter.get_input()
     |> update_board()
-    |> reset_current_move()
   end
 
   defp set_current_player(state) do
@@ -23,9 +22,5 @@ defmodule ElixirTicTacToeBasic.Player do
     Map.update(state, :board, board, fn board ->
       Map.put(board, current_move, current_player)
     end)
-  end
-
-  defp reset_current_move(state) do
-    Map.put(state, :current_move, nil)
   end
 end

--- a/lib/elixir_tic_tac_toe_basic/player.ex
+++ b/lib/elixir_tic_tac_toe_basic/player.ex
@@ -3,10 +3,10 @@ defmodule ElixirTicTacToeBasic.Player do
   This module provides functions for making moves in the game.
   """
 
-  def move(%{prompter: prompter, gets: gets} = state) do
+  def move(%{prompter: prompter} = state) do
     state
     |> set_current_player()
-    |> prompter.get_input(gets)
+    |> prompter.get_input()
     |> update_board()
     |> reset_current_move()
   end

--- a/lib/elixir_tic_tac_toe_basic/prompter.ex
+++ b/lib/elixir_tic_tac_toe_basic/prompter.ex
@@ -18,7 +18,7 @@ defmodule ElixirTicTacToeBasic.Prompter do
     error_prompt = "Please enter a valid number (1-9).\n"
 
     gets.(state, error_prompt)
-    |> integer_or_error()
+    |> validate()
     |> get_input(gets)
   end
 
@@ -26,21 +26,26 @@ defmodule ElixirTicTacToeBasic.Prompter do
     initial_prompt = "Please choose a space.\n"
 
     gets.(state, initial_prompt)
-    |> integer_or_error()
+    |> validate()
     |> get_input(gets)
   end
 
-  defp integer_or_error(%{current_move: selection} = state) do
+  defp validate(%{current_move: selection, board: board} = state) do
     converted_selection =
       selection
       |> String.trim()
       |> Integer.parse()
-      |> extract_integer()
+      |> validate_integer()
+      |> validate_availability(board)
 
     Map.put(state, :current_move, converted_selection)
   end
 
-  defp extract_integer(selection) do
+  defp validate_integer(selection) do
     if selection == :error, do: selection, else: elem(selection, 0)
+  end
+
+  defp validate_availability(selection, board) do
+    if Map.get(board, selection) in 1..9, do: selection, else: :error
   end
 end

--- a/lib/elixir_tic_tac_toe_basic/prompter.ex
+++ b/lib/elixir_tic_tac_toe_basic/prompter.ex
@@ -7,35 +7,14 @@ defmodule ElixirTicTacToeBasic.Prompter do
     %{state | current_move: _get_input(state)}
   end
 
-  defp _get_input(%{gets: gets} = state) do
+  defp _get_input(%{gets: gets, validator: validator} = state) do
     initial_prompt = "Please choose a valid space.\n"
 
-    validated_input = gets.(state, initial_prompt) |> validate()
+    validated_input = gets.(state, initial_prompt) |> validator.validate()
 
     case validated_input do
       :error -> _get_input(state)
       selection -> selection
     end
-  end
-
-  defp validate(%{current_move: selection, board: board} = _state) do
-      selection
-      |> trim_and_parse()
-      |> validate_integer()
-      |> validate_availability(board)
-  end
-
-  defp trim_and_parse(selection) do
-    selection
-    |> String.trim()
-    |> Integer.parse()
-  end
-
-  defp validate_integer(selection) do
-    if selection == :error, do: selection, else: elem(selection, 0)
-  end
-
-  defp validate_availability(selection, board) do
-    if Map.get(board, selection) in 1..9, do: selection, else: :error
   end
 end

--- a/lib/elixir_tic_tac_toe_basic/prompter.ex
+++ b/lib/elixir_tic_tac_toe_basic/prompter.ex
@@ -3,35 +3,26 @@ defmodule ElixirTicTacToeBasic.Prompter do
   Prompts the user and returns valid input
   """
 
-  def get_input(%{current_move: prev_selection} = state) when prev_selection in 1..9 do
-    state
+  def get_input(state) do
+    %{state | current_move: _get_input(state)}
   end
 
-  def get_input(%{current_move: prev_selection, gets: gets} = state)
-      when not is_nil(prev_selection) do
-    error_prompt = "Please enter a valid number.\n"
+  defp _get_input(%{gets: gets} = state) do
+    initial_prompt = "Please choose a valid space.\n"
 
-    gets.(state, error_prompt)
-    |> validate()
-    |> get_input()
+    validated_input = gets.(state, initial_prompt) |> validate()
+
+    case validated_input do
+      :error -> _get_input(state)
+      selection -> selection
+    end
   end
 
-  def get_input(%{gets: gets} = state) do
-    initial_prompt = "Please choose a space.\n"
-
-    gets.(state, initial_prompt)
-    |> validate()
-    |> get_input()
-  end
-
-  defp validate(%{current_move: selection, board: board} = state) do
-    converted_selection =
+  defp validate(%{current_move: selection, board: board} = _state) do
       selection
       |> trim_and_parse()
       |> validate_integer()
       |> validate_availability(board)
-
-    Map.put(state, :current_move, converted_selection)
   end
 
   defp trim_and_parse(selection) do

--- a/lib/elixir_tic_tac_toe_basic/prompter.ex
+++ b/lib/elixir_tic_tac_toe_basic/prompter.ex
@@ -10,19 +10,19 @@ defmodule ElixirTicTacToeBasic.Prompter do
         end
       )
 
-  def get_input(%{current_move: prev_selection} = state, gets) when prev_selection in 1..9 do
+  def get_input(%{current_move: prev_selection} = state, _gets) when prev_selection in 1..9 do
     state
   end
 
   def get_input(%{current_move: prev_selection} = state, gets) when not is_nil(prev_selection) do
-    error_prompt = "Please enter a valid number (1-9).\n"
+    error_prompt = "Please enter a valid number.\n"
 
     gets.(state, error_prompt)
     |> validate()
     |> get_input(gets)
   end
 
-  def get_input(%{current_move: prev_selection} = state, gets) do
+  def get_input(%{current_move: _prev_selection} = state, gets) do
     initial_prompt = "Please choose a space.\n"
 
     gets.(state, initial_prompt)
@@ -33,12 +33,17 @@ defmodule ElixirTicTacToeBasic.Prompter do
   defp validate(%{current_move: selection, board: board} = state) do
     converted_selection =
       selection
-      |> String.trim()
-      |> Integer.parse()
+      |> trim_and_parse()
       |> validate_integer()
       |> validate_availability(board)
 
     Map.put(state, :current_move, converted_selection)
+  end
+
+  defp trim_and_parse(selection) do
+    selection
+    |> String.trim()
+    |> Integer.parse()
   end
 
   defp validate_integer(selection) do

--- a/lib/elixir_tic_tac_toe_basic/prompter.ex
+++ b/lib/elixir_tic_tac_toe_basic/prompter.ex
@@ -3,31 +3,25 @@ defmodule ElixirTicTacToeBasic.Prompter do
   Prompts the user and returns valid input
   """
 
-  def get_input(
-        state,
-        gets \\ fn state, prompt ->
-          Map.put(state, :current_move, IO.gets(prompt))
-        end
-      )
-
-  def get_input(%{current_move: prev_selection} = state, _gets) when prev_selection in 1..9 do
+  def get_input(%{current_move: prev_selection} = state) when prev_selection in 1..9 do
     state
   end
 
-  def get_input(%{current_move: prev_selection} = state, gets) when not is_nil(prev_selection) do
+  def get_input(%{current_move: prev_selection, gets: gets} = state)
+      when not is_nil(prev_selection) do
     error_prompt = "Please enter a valid number.\n"
 
     gets.(state, error_prompt)
     |> validate()
-    |> get_input(gets)
+    |> get_input()
   end
 
-  def get_input(%{current_move: _prev_selection} = state, gets) do
+  def get_input(%{gets: gets} = state) do
     initial_prompt = "Please choose a space.\n"
 
     gets.(state, initial_prompt)
     |> validate()
-    |> get_input(gets)
+    |> get_input()
   end
 
   defp validate(%{current_move: selection, board: board} = state) do

--- a/lib/elixir_tic_tac_toe_basic/validator.ex
+++ b/lib/elixir_tic_tac_toe_basic/validator.ex
@@ -1,0 +1,27 @@
+defmodule ElixirTicTacToeBasic.Validator do
+  @moduledoc """
+  This module determines whether the user's input is a valid integer,
+  as well as whether it corresponds to an available space on the board.
+  """
+
+  def validate(%{current_move: selection, board: board} = _state) do
+    selection
+    |> trim_and_parse()
+    |> validate_integer()
+    |> validate_availability(board)
+  end
+
+  defp trim_and_parse(selection) do
+    selection
+    |> String.trim()
+    |> Integer.parse()
+  end
+
+  defp validate_integer(selection) do
+    if selection == :error, do: selection, else: elem(selection, 0)
+  end
+
+  defp validate_availability(selection, board) do
+    if Map.get(board, selection) in 1..9, do: selection, else: :error
+  end
+end

--- a/test/acceptance_test.exs
+++ b/test/acceptance_test.exs
@@ -3,12 +3,13 @@ defmodule AcceptanceTest do
 
   describe "acceptance" do
     test "the game works when run from the command line" do
-      {status, %Rambo{out: output}} = Rambo.run("./elixir_tic_tac_toe_basic", in: "5\n")
+      {_status, %Rambo{out: output}} = Rambo.run("./elixir_tic_tac_toe_basic", in: ["5\n", "9\n"])
 
       output = String.downcase(output)
 
       assert String.contains?(output, "welcome")
       assert String.contains?(output, "4 | x | 6")
+      assert String.contains?(output, "7 | 8 | o")
     end
   end
 end

--- a/test/elixir_tic_tac_toe_basic_test.exs
+++ b/test/elixir_tic_tac_toe_basic_test.exs
@@ -33,6 +33,8 @@ defmodule ElixirTicTacToeBasicTest do
                "welcome",
                "display board",
                "player moves",
+               "display board",
+               "player moves",
                "display board"
              ]
     end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -3,6 +3,10 @@ defmodule IntegrationTest do
 
   describe "integration" do
     test "it plays the game" do
+      user_input = ["5\n", "1\n"]
+
+      Helpers.Stack.setup(user_input)
+
       %{messages: messages} =
         ElixirTicTacToeBasic.start(%{
           ui: ElixirTicTacToeBasic.UI,
@@ -10,8 +14,11 @@ defmodule IntegrationTest do
           prompter: ElixirTicTacToeBasic.Prompter,
           player: ElixirTicTacToeBasic.Player,
           board: ElixirTicTacToeBasic.Board.new(),
-          current_player: "X",
-          current_move: 5
+          current_player: nil,
+          current_move: nil,
+          gets: fn state, _prompt ->
+            Map.put(state, :current_move, Helpers.Stack.pop())
+          end
         })
 
       empty_board = """
@@ -30,13 +37,24 @@ defmodule IntegrationTest do
        7 | 8 | 9
       """
 
+      board_with_second_move = """
+       O | 2 | 3
+      ---+---+---
+       4 | X | 6
+      ---+---+---
+       7 | 8 | 9
+      """
+
       messages = Enum.reverse(messages)
 
       assert messages == [
                "Welcome to Tic Tac Toe!",
                empty_board,
-               board_with_first_move
+               board_with_first_move,
+               board_with_second_move
              ]
+
+      Helpers.Stack.teardown()
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -13,6 +13,7 @@ defmodule IntegrationTest do
           presenter: ElixirTicTacToeBasic.Presenter,
           prompter: ElixirTicTacToeBasic.Prompter,
           player: ElixirTicTacToeBasic.Player,
+          validator: ElixirTicTacToeBasic.Validator,
           board: ElixirTicTacToeBasic.Board.new(),
           current_player: nil,
           current_move: nil,

--- a/test/player_test.exs
+++ b/test/player_test.exs
@@ -3,7 +3,7 @@ defmodule PlayerTest do
   doctest ElixirTicTacToeBasic.Player
 
   defmodule PlayerTest.TestPrompter do
-    def get_input(state, _gets) do
+    def get_input(state) do
       Map.put(state, :current_move, 5)
     end
   end

--- a/test/player_test.exs
+++ b/test/player_test.exs
@@ -60,21 +60,5 @@ defmodule PlayerTest do
 
       assert board == board_with_o_marker
     end
-
-    test "it resets the current move in state at the end of the turn" do
-      state = %{
-        prompter: PlayerTest.TestPrompter,
-        board: ElixirTicTacToeBasic.Board.new(),
-        current_move: nil,
-        current_player: nil,
-        gets: fn state, prompt ->
-          Map.put(state, :current_move, IO.gets(prompt))
-        end
-      }
-
-      %{current_move: current_move} = ElixirTicTacToeBasic.Player.move(state)
-
-      assert current_move == nil
-    end
   end
 end

--- a/test/player_test.exs
+++ b/test/player_test.exs
@@ -3,7 +3,7 @@ defmodule PlayerTest do
   doctest ElixirTicTacToeBasic.Player
 
   defmodule PlayerTest.TestPrompter do
-    def get_input(state) do
+    def get_input(state, _gets) do
       Map.put(state, :current_move, 5)
     end
   end
@@ -14,7 +14,8 @@ defmodule PlayerTest do
         prompter: PlayerTest.TestPrompter,
         board: ElixirTicTacToeBasic.Board.new(),
         current_move: nil,
-        current_player: "X"
+        current_player: nil,
+        gets: nil
       }
 
       board_with_first_move = %{
@@ -32,6 +33,48 @@ defmodule PlayerTest do
       %{board: board} = ElixirTicTacToeBasic.Player.move(state)
 
       assert board == board_with_first_move
+    end
+
+    test "it switches to the correct player at the beginning of the turn" do
+      state = %{
+        prompter: PlayerTest.TestPrompter,
+        board: ElixirTicTacToeBasic.Board.new(),
+        current_move: nil,
+        current_player: "X",
+        gets: nil
+      }
+
+      board_with_o_marker = %{
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+        5 => "O",
+        6 => 6,
+        7 => 7,
+        8 => 8,
+        9 => 9
+      }
+
+      %{board: board} = ElixirTicTacToeBasic.Player.move(state)
+
+      assert board == board_with_o_marker
+    end
+
+    test "it resets the current move in state at the end of the turn" do
+      state = %{
+        prompter: PlayerTest.TestPrompter,
+        board: ElixirTicTacToeBasic.Board.new(),
+        current_move: nil,
+        current_player: nil,
+        gets: fn state, prompt ->
+          Map.put(state, :current_move, IO.gets(prompt))
+        end
+      }
+
+      %{current_move: current_move} = ElixirTicTacToeBasic.Player.move(state)
+
+      assert current_move == nil
     end
   end
 end

--- a/test/prompter_test.exs
+++ b/test/prompter_test.exs
@@ -2,6 +2,18 @@ defmodule PrompterTest do
   use ExUnit.Case
   doctest ElixirTicTacToeBasic.Prompter
 
+  defmodule TestValidatorReturnsValidSelection do
+    def validate(_state) do
+      1
+    end
+  end
+
+  defmodule TestValidatorReturnsErrorThenValidSelection do
+    def validate(_state) do
+      Helpers.Stack.pop()
+    end
+  end
+
   describe "#get_input" do
     test "it stores valid input in state" do
       user_input = "1\n"
@@ -9,6 +21,7 @@ defmodule PrompterTest do
       state = %{
         current_move: nil,
         board: ElixirTicTacToeBasic.Board.new(),
+        validator: PrompterTest.TestValidatorReturnsValidSelection,
         gets: fn state, _prompt ->
           Map.put(state, :current_move, user_input)
         end
@@ -20,24 +33,15 @@ defmodule PrompterTest do
     end
 
     test "it keeps prompting the user until valid input is received" do
-      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
-      Helpers.Stack.setup(user_input)
+      validated_input = [:error, 1]
+      Helpers.Stack.setup(validated_input)
 
       state = %{
         current_move: nil,
-        board: %{
-          1 => 1,
-          2 => 2,
-          3 => 3,
-          4 => 4,
-          5 => "X",
-          6 => 6,
-          7 => 7,
-          8 => 8,
-          9 => 9
-        },
+        board: ElixirTicTacToeBasic.Board.new(),
+        validator: PrompterTest.TestValidatorReturnsErrorThenValidSelection,
         gets: fn state, _prompt ->
-          Map.put(state, :current_move, Helpers.Stack.pop())
+          %{state | current_move: "invalid selection"}
         end
       }
 

--- a/test/prompter_test.exs
+++ b/test/prompter_test.exs
@@ -5,7 +5,8 @@ defmodule PrompterTest do
   describe "#get_input" do
     test "it stores valid input in state" do
       state = %{
-        current_move: nil
+        current_move: nil,
+        board: ElixirTicTacToeBasic.Board.new()
       }
 
       user_input = "1\n"
@@ -20,10 +21,21 @@ defmodule PrompterTest do
 
     test "it keeps prompting the user until valid input is received" do
       state = %{
-        current_move: nil
+        current_move: nil,
+        board: %{
+          1 => 1,
+          2 => 2,
+          3 => 3,
+          4 => 4,
+          5 => "X",
+          6 => 6,
+          7 => 7,
+          8 => 8,
+          9 => 9
+        }
       }
 
-      user_input = ["abc", "10\n", "-1\n", "1\n"]
+      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
 
       Helpers.Stack.setup(user_input)
 
@@ -40,10 +52,21 @@ defmodule PrompterTest do
     test "it uses the correct prompt for the situation (error or not)" do
       state = %{
         messages: [],
-        current_move: nil
+        current_move: nil,
+        board: %{
+          1 => 1,
+          2 => 2,
+          3 => 3,
+          4 => 4,
+          5 => "X",
+          6 => 6,
+          7 => 7,
+          8 => 8,
+          9 => 9
+        }
       }
 
-      user_input = ["abc", "10\n", "-1\n", "1\n"]
+      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
 
       Helpers.Stack.setup(user_input)
 
@@ -59,6 +82,7 @@ defmodule PrompterTest do
 
       assert messages == [
                "Please choose a space.\n",
+               "Please enter a valid number (1-9).\n",
                "Please enter a valid number (1-9).\n",
                "Please enter a valid number (1-9).\n",
                "Please enter a valid number (1-9).\n"

--- a/test/prompter_test.exs
+++ b/test/prompter_test.exs
@@ -47,53 +47,5 @@ defmodule PrompterTest do
 
       Helpers.Stack.teardown()
     end
-
-    test "it uses the correct prompt for the situation (error or not)" do
-      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
-      Helpers.Stack.setup(user_input)
-
-      state = %{
-        messages: [],
-        current_move: nil,
-        board: %{
-          1 => 1,
-          2 => 2,
-          3 => 3,
-          4 => 4,
-          5 => "X",
-          6 => 6,
-          7 => 7,
-          8 => 8,
-          9 => 9
-        },
-        gets: fn state, prompt ->
-          Map.put(state, :current_move, Helpers.Stack.pop())
-          |> record_message(prompt)
-        end
-      }
-
-      %{messages: messages, current_move: current_move} =
-        ElixirTicTacToeBasic.Prompter.get_input(state)
-
-      assert current_move == 1
-
-      messages = Enum.reverse(messages)
-
-      assert messages == [
-               "Please choose a space.\n",
-               "Please enter a valid number.\n",
-               "Please enter a valid number.\n",
-               "Please enter a valid number.\n",
-               "Please enter a valid number.\n"
-             ]
-
-      Helpers.Stack.teardown()
-    end
-  end
-
-  defp record_message(state, message) do
-    Map.update(state, :messages, [], fn messages ->
-      [message | messages]
-    end)
   end
 end

--- a/test/prompter_test.exs
+++ b/test/prompter_test.exs
@@ -6,7 +6,10 @@ defmodule PrompterTest do
     test "it stores valid input in state" do
       state = %{
         current_move: nil,
-        board: ElixirTicTacToeBasic.Board.new()
+        board: ElixirTicTacToeBasic.Board.new(),
+        default_gets: fn state, prompt ->
+          Map.put(state, :current_move, IO.gets(prompt))
+        end
       }
 
       user_input = "1\n"
@@ -82,10 +85,10 @@ defmodule PrompterTest do
 
       assert messages == [
                "Please choose a space.\n",
-               "Please enter a valid number (1-9).\n",
-               "Please enter a valid number (1-9).\n",
-               "Please enter a valid number (1-9).\n",
-               "Please enter a valid number (1-9).\n"
+               "Please enter a valid number.\n",
+               "Please enter a valid number.\n",
+               "Please enter a valid number.\n",
+               "Please enter a valid number.\n"
              ]
 
       Helpers.Stack.teardown()

--- a/test/prompter_test.exs
+++ b/test/prompter_test.exs
@@ -4,25 +4,25 @@ defmodule PrompterTest do
 
   describe "#get_input" do
     test "it stores valid input in state" do
+      user_input = "1\n"
+
       state = %{
         current_move: nil,
         board: ElixirTicTacToeBasic.Board.new(),
-        default_gets: fn state, prompt ->
-          Map.put(state, :current_move, IO.gets(prompt))
+        gets: fn state, _prompt ->
+          Map.put(state, :current_move, user_input)
         end
       }
 
-      user_input = "1\n"
-
-      %{current_move: current_move} =
-        ElixirTicTacToeBasic.Prompter.get_input(state, fn _state, _prompt ->
-          Map.put(state, :current_move, user_input)
-        end)
+      %{current_move: current_move} = ElixirTicTacToeBasic.Prompter.get_input(state)
 
       assert current_move == 1
     end
 
     test "it keeps prompting the user until valid input is received" do
+      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
+      Helpers.Stack.setup(user_input)
+
       state = %{
         current_move: nil,
         board: %{
@@ -35,17 +35,13 @@ defmodule PrompterTest do
           7 => 7,
           8 => 8,
           9 => 9
-        }
+        },
+        gets: fn state, _prompt ->
+          Map.put(state, :current_move, Helpers.Stack.pop())
+        end
       }
 
-      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
-
-      Helpers.Stack.setup(user_input)
-
-      %{current_move: current_move} =
-        ElixirTicTacToeBasic.Prompter.get_input(state, fn _state, _prompt ->
-          Map.put(state, :current_move, Helpers.Stack.pop())
-        end)
+      %{current_move: current_move} = ElixirTicTacToeBasic.Prompter.get_input(state)
 
       assert current_move == 1
 
@@ -53,6 +49,9 @@ defmodule PrompterTest do
     end
 
     test "it uses the correct prompt for the situation (error or not)" do
+      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
+      Helpers.Stack.setup(user_input)
+
       state = %{
         messages: [],
         current_move: nil,
@@ -66,18 +65,15 @@ defmodule PrompterTest do
           7 => 7,
           8 => 8,
           9 => 9
-        }
-      }
-
-      user_input = ["abc", "10\n", "-1\n", "5\n", "1\n"]
-
-      Helpers.Stack.setup(user_input)
-
-      %{messages: messages, current_move: current_move} =
-        ElixirTicTacToeBasic.Prompter.get_input(state, fn state, prompt ->
+        },
+        gets: fn state, prompt ->
           Map.put(state, :current_move, Helpers.Stack.pop())
           |> record_message(prompt)
-        end)
+        end
+      }
+
+      %{messages: messages, current_move: current_move} =
+        ElixirTicTacToeBasic.Prompter.get_input(state)
 
       assert current_move == 1
 

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -6,17 +6,7 @@ defmodule ValidatorTest do
     test "when input is valid, it returns the selection" do
       state = %{
         current_move: "1\n",
-        board: %{
-          1 => 1,
-          2 => 2,
-          3 => 3,
-          4 => 4,
-          5 => 5,
-          6 => 6,
-          7 => 7,
-          8 => 8,
-          9 => 9
-        }
+        board: ElixirTicTacToeBasic.Board.new()
       }
 
       selection = ElixirTicTacToeBasic.Validator.validate(state)
@@ -27,17 +17,7 @@ defmodule ValidatorTest do
     test "when input is not a valid number, it returns :error" do
       state = %{
         current_move: "asdf\n",
-        board: %{
-          1 => 1,
-          2 => 2,
-          3 => 3,
-          4 => 4,
-          5 => 5,
-          6 => 6,
-          7 => 7,
-          8 => 8,
-          9 => 9
-        }
+        board: ElixirTicTacToeBasic.Board.new()
       }
 
       selection = ElixirTicTacToeBasic.Validator.validate(state)

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -1,0 +1,69 @@
+defmodule ValidatorTest do
+  use ExUnit.Case
+  doctest ElixirTicTacToeBasic.Validator
+
+  describe "validate" do
+    test "when input is valid, it returns the selection" do
+      state = %{
+        current_move: "1\n",
+        board: %{
+          1 => 1,
+          2 => 2,
+          3 => 3,
+          4 => 4,
+          5 => 5,
+          6 => 6,
+          7 => 7,
+          8 => 8,
+          9 => 9
+        }
+      }
+
+      selection = ElixirTicTacToeBasic.Validator.validate(state)
+
+      assert selection == 1
+    end
+
+    test "when input is not a valid number, it returns :error" do
+      state = %{
+        current_move: "asdf\n",
+        board: %{
+          1 => 1,
+          2 => 2,
+          3 => 3,
+          4 => 4,
+          5 => 5,
+          6 => 6,
+          7 => 7,
+          8 => 8,
+          9 => 9
+        }
+      }
+
+      selection = ElixirTicTacToeBasic.Validator.validate(state)
+
+      assert selection == :error
+    end
+
+    test "when input corresponds to an unavailable space, it returns :error" do
+      state = %{
+        current_move: "1\n",
+        board: %{
+          1 => "X",
+          2 => 2,
+          3 => 3,
+          4 => 4,
+          5 => 5,
+          6 => 6,
+          7 => 7,
+          8 => 8,
+          9 => 9
+        }
+      }
+
+      selection = ElixirTicTacToeBasic.Validator.validate(state)
+
+      assert selection == :error
+    end
+  end
+end


### PR DESCRIPTION
Acceptance Criteria: 
- When the game starts, and after the first player chooses a space, the second player is prompted to choose a space.
- After the second player's selection is made, the board is displayed again and an `X` appears in the first player's chosen spot, and an `O` appears in the second player's chosen spot.
- The second player cannot choose the same space the first player chose.

Questions:
- Damon and I talked about changing dependencies injected into` CLI.main()` so that they're all at the same abstraction level. I started to create a nested map to hold the `board`, `current_move`, and `current_player` keys, but I was having a bit of trouble refactoring `Prompter` to make it work correctly with the nested data structures. It may just be that I need practice accessing information from nested data structures, but I figured I'd see if there was a better way of doing this. 
- I'm planning on moving the validation logic from `Prompter` to a separate module. Any reason not to do so? 