### PR TITLE
Upgrade tool versions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-22
+    runs-on: ubuntu-20
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
       with:
-        elixir-version: '1.13.4' # Define the elixir version [required]
-        otp-version: '24.1' # Define the OTP version [required]
+        elixir-version: '1.14.1' # Define the elixir version [required]
+        otp-version: '26.1' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-20
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22
 
     steps:
     - uses: actions/checkout@v3

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule ElixirTicTacToeBasic.MixProject do
   def project do
     [
       app: :elixir_tic_tac_toe_basic,
-      version: "0.1.0",
-      elixir: "~> 1.13.4",
+      version: "0.1.1",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),


### PR DESCRIPTION
- Upgrades Elixir and Erlang versions to fix a bug related to the new MacOs version
- Pins CI's Ubuntu version to 20.04 as the latest GitHub Actions Ubuntu image (22.04) [does not support Erlang](https://github.com/actions/runner-images/issues/5490)